### PR TITLE
Ensure PF2e roll dialogs function in popouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In addition, systems using more advanced frameworks like react/svelte/vue will l
 
 ### jQuery global handlers and PF2e
 
-Pop-out windows now mirror jQuery's global event handlers so modules relying on them behave correctly. PopOut! has been tested with the Pathfinder Second Edition (PF2e) system.
+Pop-out windows now mirror jQuery's global event handlers so modules relying on them behave correctly. PopOut! has been tested with the Pathfinder Second Edition (PF2e) system, and for PF2e this cloning is always enabled to ensure skill check dialogs function in popped-out sheets.
 
 Due to the necessarily brittle nature of how this module is implemented, other modules may lack functionality or break completely when popped out. See the Compatibility section for a description of how you can fix this if you are module developer.
 

--- a/popout.js
+++ b/popout.js
@@ -150,7 +150,7 @@ class PopoutModule {
     });
     game.settings.register("popout", "cloneDocumentEvents", {
       name: "Clone document event handlers",
-      hint: "Copy delegated document and body event handlers into popout windows. Enabled automatically for PF2e.",
+      hint: "Copy delegated document and body event handlers into popout windows. Always enabled for PF2e.",
       scope: "client",
       config: true,
       default: game.system.id === "pf2e",
@@ -1225,7 +1225,10 @@ class PopoutModule {
         // For v13, if no API available, let the event bubble normally
       });
 
-      if (game.settings.get("popout", "cloneDocumentEvents")) {
+      if (
+        game.settings.get("popout", "cloneDocumentEvents") ||
+        game.system.id === "pf2e"
+      ) {
         try {
           this.cloneDelegatedEvents(popout);
         } catch (err) {


### PR DESCRIPTION
## Summary
- Always clone delegated document events for PF2e to keep roll dialogs working in popped-out windows
- Clarify documentation that PF2e event cloning is always enabled

## Testing
- `make lint`
- `make format`
- `make test` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a89fa5ccd08327a12726a867afe3ee