### PR TITLE
Seed native event listeners for popouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Pop-out windows now mirror jQuery's global event handlers so modules relying on 
 
 Due to the necessarily brittle nature of how this module is implemented, other modules may lack functionality or break completely when popped out. See the Compatibility section for a description of how you can fix this if you are module developer.
 
+### Native event listeners
+
+At startup PopOut! tries to copy any existing listeners attached to `window`, `document`, or `document.body` into new pop-out windows. Chromium-based browsers expose a non-standard `getEventListeners` function which allows full enumeration. Other browsers fall back to inspecting `on*` properties, so listeners registered via `addEventListener` may not be detected.
+
 ### Firefox
 
 ~Due to a recent update from Firefox that changed the way the `instanceof` method works~ Turns out [the issue](https://bugzilla.mozilla.org/show_bug.cgi?id=339884) is 17 years old, I have no idea why some things are encountering it now. Some core JQuery functions are broken when operating on popped out HTML nodes. Therefore **I am no longer supporting Firefox**, please use Chrome. If you are interested, the following gist can [replicate the issue](https://gist.github.com/Posnet/9d87f790d4f3c64ed468559600c76302).
@@ -52,7 +56,7 @@ If you are a module developer have found that PopOut! is not working correctly o
 A second option is when creating an application or dialog, you can add the `popOutModuleDisable` attribute to it's options argument, this will also disable PopOut for that specific object. For example:
 
 ```js
-Dialog.prompt({ title: '', options: { popOutModuleDisable: true } });
+Dialog.prompt({ title: "", options: { popOutModuleDisable: true } });
 ```
 
 ### Sidebar (ChatLog...)
@@ -64,7 +68,9 @@ For example if you want to hide a chat card, you will have to do the following.
 ```js
 ui.chat.element.find(`.message[data-message-id=${data._id}]`).hide();
 if (ui.sidebar.popouts.chat) {
-    ui.sidebar.popouts.chat.element.find(`.message[data-message-id=${data._id}]`).hide();
+  ui.sidebar.popouts.chat.element
+    .find(`.message[data-message-id=${data._id}]`)
+    .hide();
 }
 ```
 
@@ -90,26 +96,26 @@ For an example of what that might look like, see the PDFoundry compatibility hoo
 ```javascript
 // app: is the foundry application being popped out.
 // popout: is the browser window object where the popped out element will be moved.
-Hooks.callAll('PopOut:popout', app, popout);
+Hooks.callAll("PopOut:popout", app, popout);
 
 // app: is the foundry application being popped out.
 // node: is the html element of the application after it has been moved to the new window.
-Hooks.callAll('Popout:loaded', app, node);
+Hooks.callAll("Popout:loaded", app, node);
 
 // app: is the foundry application being popped out.
 // popout: is the browser window object where the popped out element will be moved.
-Hooks.callAll('Popout:loading', app, popout);
+Hooks.callAll("Popout:loading", app, popout);
 
 // app: is the foundry application being popped in.
-Hooks.callAll('PopOut:popin', app);
+Hooks.callAll("PopOut:popin", app);
 
 // app: is the foundry application being popped out.
 // parent: The application that PopOut believes owns the diaglog box.
-Hooks.callAll('PopOut:dialog', app, parent);
+Hooks.callAll("PopOut:dialog", app, parent);
 
 // app: is the foundry application being popped out.
 // node: is the html element of the popped out application, before it is deleted or popped in.
-Hooks.callAll('PopOut:close', app, node);
+Hooks.callAll("PopOut:close", app, node);
 ```
 
 # License


### PR DESCRIPTION
## Summary
- Track native event listeners on `window`, `document`, and `document.body`
- Clone existing native listeners into new pop-out windows
- Describe browser limitations for enumerating listeners

## Testing
- `npx prettier --check popout.js README.md`
- `npx eslint popout.js` *(produced no output)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8b12c88cc83278bcb502f6a460660