### PR TITLE
Clone direct event handlers in popouts

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -651,18 +651,27 @@ class PopoutModule {
       if (!events) return;
       for (const [type, handlers] of Object.entries(events)) {
         for (const handler of handlers) {
-          if (!handler.selector) continue;
           const namespace = handler.namespace ? `.${handler.namespace}` : "";
           const eventName = `${type}${namespace}`;
-          if (handler.data !== undefined) {
-            jq(target).on(
-              eventName,
-              handler.selector,
-              handler.data,
-              handler.handler,
-            );
+          if (handler.selector) {
+            if (handler.data !== undefined) {
+              jq(target).on(
+                eventName,
+                handler.selector,
+                handler.data,
+                handler.handler,
+              );
+            } else {
+              jq(target).on(eventName, handler.selector, handler.handler);
+            }
           } else {
-            jq(target).on(eventName, handler.selector, handler.handler);
+            // PF2e skill checks rely on direct document handlers,
+            // so we need to clone non-delegated handlers as well
+            if (handler.data !== undefined) {
+              jq(target).on(eventName, handler.data, handler.handler);
+            } else {
+              jq(target).on(eventName, handler.handler);
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary
- Clone both delegated and direct jQuery handlers when mirroring events to popout windows
- Use the popout's own jQuery context for event registration
- Document PF2e skill check requirement for cloning direct handlers

## Testing
- `npx eslint popout.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a9852ccb808327a2d2c794c3ee6a28