### PR TITLE
Clone event listeners in second screen popouts

### DIFF
--- a/scripts/second-screen.js
+++ b/scripts/second-screen.js
@@ -1,0 +1,103 @@
+"use strict";
+
+async function openSecondScreen(sheet) {
+  const popout = await sheet.render(true, { popOut: true });
+
+  const jq = popout.jQuery || window.jQuery;
+  const cloneDelegated = (source, target) => {
+    const events = window.jQuery._data(source, "events");
+    if (!events) return;
+    for (const [type, handlers] of Object.entries(events)) {
+      for (const handler of handlers) {
+        const namespace = handler.namespace ? `.${handler.namespace}` : "";
+        const eventName = `${type}${namespace}`;
+        if (handler.selector) {
+          if (handler.data !== undefined) {
+            jq(target).on(
+              eventName,
+              handler.selector,
+              handler.data,
+              handler.handler,
+            );
+          } else {
+            jq(target).on(eventName, handler.selector, handler.handler);
+          }
+        } else {
+          if (handler.data !== undefined) {
+            jq(target).on(eventName, handler.data, handler.handler);
+          } else {
+            jq(target).on(eventName, handler.handler);
+          }
+        }
+      }
+    }
+  };
+
+  cloneDelegated(window.document, popout.document);
+  if (document.body && popout.document.body) {
+    cloneDelegated(document.body, popout.document.body);
+  }
+
+  const origAdd = EventTarget.prototype.addEventListener;
+  const origRemove = EventTarget.prototype.removeEventListener;
+  const pairs = [
+    [window.document, popout.document],
+    [window.document.body, popout.document.body],
+  ];
+
+  const seed = (source, target) => {
+    if (!source || !target) return;
+    const getter =
+      typeof getEventListeners === "function" ? getEventListeners : null;
+    if (getter) {
+      try {
+        const listeners = getter(source);
+        for (const [type, arr] of Object.entries(listeners)) {
+          for (const l of arr) {
+            const opts = l.options ?? l.useCapture ?? l.capture ?? false;
+            origAdd.call(target, type, l.listener, opts);
+          }
+        }
+        return;
+      } catch (_err) {
+        /* ignore */
+      }
+    }
+    for (const key in source) {
+      if (key.startsWith("on") && typeof source[key] === "function") {
+        const type = key.slice(2);
+        origAdd.call(target, type, source[key], false);
+      }
+    }
+  };
+
+  for (const [src, tgt] of pairs) seed(src, tgt);
+
+  EventTarget.prototype.addEventListener = function (type, listener, options) {
+    const result = origAdd.call(this, type, listener, options);
+    for (const [src, tgt] of pairs) {
+      if (this === src && tgt) {
+        origAdd.call(tgt, type, listener, options);
+      }
+    }
+    return result;
+  };
+
+  EventTarget.prototype.removeEventListener = function (
+    type,
+    listener,
+    options,
+  ) {
+    const result = origRemove.call(this, type, listener, options);
+    for (const [src, tgt] of pairs) {
+      if (this === src && tgt) {
+        origRemove.call(tgt, type, listener, options);
+      }
+    }
+    return result;
+  };
+
+  return popout;
+}
+
+window.openSecondScreen = openSecondScreen;


### PR DESCRIPTION
## Summary
- Clone jQuery delegated events from document and body to second-screen popouts
- Mirror native event listeners via addEventListener in popout documents

## Testing
- `npx eslint scripts/second-screen.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*

------
https://chatgpt.com/codex/tasks/task_e_68a9b66944c88327b09f6fb61bf9ebf8