### PR TITLE
refactor: move use strict directive

### DIFF
--- a/scripts/second-screen.js
+++ b/scripts/second-screen.js
@@ -1,8 +1,9 @@
-
 /**
  * Utilities for PF2e second-screen interactions.
  * Adjusted for PF2e v13 DOM structure.
  */
+
+"use strict";
 
 /**
  * Trigger a PF2e skill roll.
@@ -37,7 +38,6 @@ if (typeof window !== "undefined") {
   window.triggerSkillRoll = triggerSkillRoll;
   window.triggerRollCheck = triggerRollCheck;
 }
-"use strict";
 
 async function openSecondScreen(sheet) {
   const popout = await sheet.render(true, { popOut: true });


### PR DESCRIPTION
## Summary
- move "use strict" directive to start of second-screen.js

## Testing
- `npx eslint scripts/second-screen.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9bbf641848327a75698ba4218a052