### PR TITLE
Add cleanup to second-screen popouts

### DIFF
--- a/scripts/second-screen.js
+++ b/scripts/second-screen.js
@@ -148,6 +148,20 @@ async function openSecondScreen(sheet) {
     isPatched = true;
   }
 
+  const cleanup = () => {
+    for (const pair of newPairs) {
+      const idx = pairs.indexOf(pair);
+      if (idx !== -1) pairs.splice(idx, 1);
+    }
+    if (pairs.length === 0) {
+      EventTarget.prototype.addEventListener = origAdd;
+      EventTarget.prototype.removeEventListener = origRemove;
+      isPatched = false;
+    }
+  };
+
+  popout.addEventListener("unload", cleanup, { once: true });
+
   return popout;
 }
 


### PR DESCRIPTION
## Summary
- clean up mirrored event listeners when a second-screen popout closes
- restore original EventTarget methods on popout unload

## Testing
- `npx prettier -w scripts/second-screen.js`
- `npx eslint scripts/second-screen.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bcb84c808327b46e724dc0370a18