### PR TITLE
Register PF2e skill check listeners on ready

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1554,6 +1554,13 @@ class PopoutModule {
 }
 
 Hooks.on("ready", () => {
+  if (
+    game.system.id === "pf2e" &&
+    typeof InlineRollLinks?.activatePF2eListeners === "function"
+  ) {
+    InlineRollLinks.activatePF2eListeners();
+  }
+
   PopoutModule.singleton = new PopoutModule();
   PopoutModule.singleton.init();
 


### PR DESCRIPTION
## Summary
- ensure PF2e inline roll listeners activate on ready so skill checks work in fresh popouts

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9bf978c6c8327b2cbc547b2f4242b