### PR TITLE
Load PF2e InlineRollLinks during setup

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1553,14 +1553,16 @@ class PopoutModule {
   }
 }
 
-Hooks.on("ready", () => {
-  if (
-    game.system.id === "pf2e" &&
-    typeof InlineRollLinks?.activatePF2eListeners === "function"
-  ) {
+Hooks.once("setup", async () => {
+  if (game.system.id === "pf2e") {
+    const { InlineRollLinks } = await import(
+      "/systems/pf2e/scripts/ui/inline-roll-links.js"
+    );
     InlineRollLinks.activatePF2eListeners();
   }
+});
 
+Hooks.on("ready", () => {
   PopoutModule.singleton = new PopoutModule();
   PopoutModule.singleton.init();
 


### PR DESCRIPTION
## Summary
- Import PF2e InlineRollLinks during the setup hook to avoid startup ReferenceErrors
- Keep PopOut! initialization in the ready hook

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- ⚠️ `npx testcafe chrome tests/` *(missing browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cc50958c8327826e20203121c42b