### PR TITLE
Use getRoute for PF2e inline roll link import

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1555,9 +1555,10 @@ class PopoutModule {
 
 Hooks.once("setup", async () => {
   if (game.system.id === "pf2e") {
-    const { InlineRollLinks } = await import(
-      "/systems/pf2e/scripts/ui/inline-roll-links.js"
+    const path = foundry.utils.getRoute(
+      "systems/pf2e/scripts/ui/inline-roll-links.js",
     );
+    const { InlineRollLinks } = await import(path);
     InlineRollLinks.activatePF2eListeners();
   }
 });


### PR DESCRIPTION
## Summary
- resolve PF2e inline roll module path via `foundry.utils.getRoute`

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a9cf2d4bac8327b21ca6a44e2f0607