### PR TITLE
fix: load PF2e inline roll links

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1556,7 +1556,7 @@ class PopoutModule {
 Hooks.once("setup", async () => {
   if (game.system.id === "pf2e") {
     const path = foundry.utils.getRoute(
-      "systems/pf2e/scripts/ui/inline-roll-links.js",
+      "systems/pf2e/scripts/ui/inline-roll-links.mjs",
     );
     const { InlineRollLinks } = await import(path);
     InlineRollLinks.activatePF2eListeners();


### PR DESCRIPTION
## Summary
- fix PF2e inline-roll listener import to use `.mjs` extension

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d6c4d0b0832780bc225483c7fd8c