### PR TITLE
Remove PF2e inline roll dynamic import to avoid popout network requests

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1553,14 +1553,8 @@ class PopoutModule {
   }
 }
 
-Hooks.once("setup", async () => {
-  if (game.system.id === "pf2e") {
-    const path = foundry.utils.getRoute(
-      "systems/pf2e/scripts/ui/inline-roll-links.mjs",
-    );
-    const { InlineRollLinks } = await import(path);
-    InlineRollLinks.activatePF2eListeners();
-  }
+Hooks.once("setup", () => {
+  if (game.system.id === "pf2e") InlineRollLinks.activatePF2eListeners();
 });
 
 Hooks.on("ready", () => {


### PR DESCRIPTION
## Summary
- call InlineRollLinks directly for PF2e without dynamic import

## Testing
- `npm test` (fails: missing script)
- `npx eslint popout.js tests/popout_tests.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9dfa619e083278b6f986685fff720