### PR TITLE
Reclone listeners on each popout load

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1438,17 +1438,22 @@ class PopoutModule {
         // For v13, if no API available, let the event bubble normally
       });
 
+      // Always refresh event listeners when the window loads so they
+      // are re-mirrored on subsequent openings.
+      this.mirroredNativeListeners.delete(popout);
       if (
         game.settings.get("popout", "cloneDocumentEvents") ||
         game.system.id === "pf2e"
       ) {
         try {
+          // Clone delegated document events afresh for the new window
           this.cloneDelegatedEvents(popout);
         } catch (err) {
           this.log("Failed to clone document events", err);
         }
       }
 
+      // Always mirror native listeners from the main document
       this.cloneNativeEventListeners(popout);
 
       popout.game = game;


### PR DESCRIPTION
## Summary
- Re-clone document-delegated and native event listeners whenever a popout window loads
- Ensure previous mirrored listeners are cleared so native listeners are re-mirrored on reopen

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npm test` *(fails: Missing script: "test")*
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*


------
https://chatgpt.com/codex/tasks/task_e_68a9f6a9ccc48327beedf5a7b417737c