### PR TITLE
Log activation of PF2e Inline Roll Links

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1561,6 +1561,7 @@ class PopoutModule {
 Hooks.once("ready", () => {
   if (game.system.id === "pf2e") {
     globalThis.InlineRollLinks?.activatePF2eListeners();
+    console.log("Inline Roll Links listeners activated");
   }
 
   PopoutModule.singleton = new PopoutModule();


### PR DESCRIPTION
## Summary
- log Inline Roll Links activation for PF2e when ready hook fires

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome" is neither a known alias nor path to executable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa090fd8e483278a78c11f6ebf2958