### PR TITLE
Ensure PF2e inline roll listeners reactivate after popout load

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1456,6 +1456,8 @@ class PopoutModule {
       // Always mirror native listeners from the main document
       this.cloneNativeEventListeners(popout);
 
+      globalThis.InlineRollLinks?.activatePF2eListeners();
+
       popout.game = game;
 
       // Only try to setup tooltip manager if it exists


### PR DESCRIPTION
## Summary
- Re-bind PF2e inline roll listeners when a popout window loads

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*

------
https://chatgpt.com/codex/tasks/task_e_68aa0c44b750832781c46ab8ca5644cc