### PR TITLE
Fix PF2e inline roll listeners in popout windows

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1456,7 +1456,8 @@ class PopoutModule {
       // Always mirror native listeners from the main document
       this.cloneNativeEventListeners(popout);
 
-      globalThis.InlineRollLinks?.activatePF2eListeners();
+      // Re-activate PF2e inline roll links within the popout window
+      popout.InlineRollLinks?.activatePF2eListeners();
 
       popout.game = game;
 


### PR DESCRIPTION
## Summary
- ensure PF2e inline roll links are activated in the popout window context

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*


------
https://chatgpt.com/codex/tasks/task_e_68aa0efe595483278529a7898631af18