### PR TITLE
Mirror InlineRollLinks in popout windows

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1457,6 +1457,10 @@ class PopoutModule {
       this.cloneNativeEventListeners(popout);
 
       // Re-activate PF2e inline roll links within the popout window
+      popout.InlineRollLinks = window.InlineRollLinks;
+      if (!popout.InlineRollLinks) {
+        this.log("InlineRollLinks not found on main window");
+      }
       popout.InlineRollLinks?.activatePF2eListeners();
 
       popout.game = game;


### PR DESCRIPTION
## Summary
- mirror `InlineRollLinks` from main window into popout windows
- log when `InlineRollLinks` is unavailable

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*


------
https://chatgpt.com/codex/tasks/task_e_68aa11a024708327871700df35a59b42