### PR TITLE
Load PF2e inline roll links in popouts

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1457,11 +1457,20 @@ class PopoutModule {
       this.cloneNativeEventListeners(popout);
 
       // Re-activate PF2e inline roll links within the popout window
-      popout.InlineRollLinks = window.InlineRollLinks;
-      if (!popout.InlineRollLinks) {
-        this.log("InlineRollLinks not found on main window");
+      if (game.system.id === "pf2e") {
+        try {
+          const response = await popout.fetch(
+            "systems/pf2e/module/inline-roll-links.js",
+          );
+          if (!response.ok)
+            throw new Error(`${response.status} ${response.statusText}`);
+          const script = await response.text();
+          popout.eval(script);
+          popout.InlineRollLinks?.activatePF2eListeners();
+        } catch (err) {
+          this.log("Failed to load inline-roll-links.js", err);
+        }
       }
-      popout.InlineRollLinks?.activatePF2eListeners();
 
       popout.game = game;
 


### PR DESCRIPTION
## Summary
- load PF2e inline-roll-links inside popout windows instead of mirroring
- invoke `activatePF2eListeners` after loading the script
- log an error if the script cannot be loaded

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx eslint popout.js`
- `npx prettier -w popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1bc913dc8327915029e4467189bb