### PR TITLE
fix: ensure PF2e listeners are mirrored before activation

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1575,13 +1575,13 @@ class PopoutModule {
 }
 
 Hooks.once("ready", () => {
+  PopoutModule.singleton = new PopoutModule();
+  PopoutModule.singleton.init();
+
   if (game.system.id === "pf2e") {
     globalThis.InlineRollLinks?.activatePF2eListeners();
     console.log("Inline Roll Links listeners activated");
   }
-
-  PopoutModule.singleton = new PopoutModule();
-  PopoutModule.singleton.init();
 
   // Add ApplicationV2 support for v13 using instance interception
   if (foundry?.applications?.instances) {


### PR DESCRIPTION
## Summary
- initialize PopoutModule before activating PF2e inline roll listeners

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68aa23b9ec848327901082a9113c3ef5