### PR TITLE
Initialize PopoutModule during init to capture PF2e listeners

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1574,10 +1574,12 @@ class PopoutModule {
   }
 }
 
-Hooks.once("ready", () => {
+Hooks.once("init", () => {
   PopoutModule.singleton = new PopoutModule();
   PopoutModule.singleton.init();
+});
 
+Hooks.once("ready", () => {
   if (game.system.id === "pf2e") {
     globalThis.InlineRollLinks?.activatePF2eListeners();
     console.log("Inline Roll Links listeners activated");


### PR DESCRIPTION
## Summary
- Initialize `PopoutModule` on the `init` hook so event interception starts earlier
- Keep PF2e Inline Roll Links activation in the `ready` hook to ensure document listeners are captured

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome" is neither a known browser alias, nor a path to an executable file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa289e86a08327b1df1984d1306fd8