### PR TITLE
Re-enable PF2e roll listeners after popout

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -539,7 +539,10 @@ class PopoutModule {
         )}"></i>${buttonText}</a>`,
       );
 
-      link.on("click", () => this.onPopoutClicked(app));
+      link.on("click", () => {
+        this.onPopoutClicked(app);
+        globalThis.InlineRollLinks?.activatePF2eListeners();
+      });
 
       // Handle both ApplicationV1 and ApplicationV2
 


### PR DESCRIPTION
## Summary
- ensure PF2e InlineRollLinks listeners are reactivated when popout button is clicked

## Testing
- `npm test` *(fails: Missing script "test" because no test script defined)*
- `npx eslint popout.js`
- `npx prettier -w popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome" in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68aa386411f883278196e2e47e8bd2c6