### PR TITLE
Initialize PF2e skill handlers on sheet render

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1565,6 +1565,12 @@ class PopoutModule {
 
 Hooks.once("ready", () => {
   if (game.system.id === "pf2e") {
+    Hooks.on("renderActorSheetPF2e", (sheet, html) => {
+      if (typeof sheet.activateListeners === "function") {
+        sheet.activateListeners(html);
+      }
+    });
+
     globalThis.InlineRollLinks?.activatePF2eListeners();
     console.log("Inline Roll Links listeners activated");
   }


### PR DESCRIPTION
## Summary
- ensure PF2e actor sheets have skill handlers on render so PopOut! picks them up

## Testing
- `make lint`
- `make test` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3ad749048327a06242f4ea69ded5