### PR TITLE
Guard PF2e sheet listener reactivation

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1566,7 +1566,11 @@ class PopoutModule {
 Hooks.once("ready", () => {
   if (game.system.id === "pf2e") {
     Hooks.on("renderActorSheetPF2e", (sheet, html) => {
-      if (typeof sheet.activateListeners === "function") {
+      if (
+        typeof sheet.activateListeners === "function" &&
+        !sheet._popoutListenersPrimed
+      ) {
+        sheet._popoutListenersPrimed = true;
         sheet.activateListeners(html);
       }
     });


### PR DESCRIPTION
## Summary
- prevent repeated activation of PF2e actor sheet listeners in popouts by guarding with `_popoutListenersPrimed`

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe "chromium:headless --no-sandbox" tests/` *(fails: Unable to open the "chromium:headless --no-sandbox" browser due to connect ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3fe1b5008327a89aafbcfc61e526