### PR TITLE
Remove PF2E system gating from ready hook

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1564,20 +1564,18 @@ class PopoutModule {
 }
 
 Hooks.once("ready", () => {
-  if (game.system.id === "pf2e") {
-    Hooks.on("renderActorSheetPF2e", (sheet, html) => {
-      if (
-        typeof sheet.activateListeners === "function" &&
-        !sheet._popoutListenersPrimed
-      ) {
-        sheet._popoutListenersPrimed = true;
-        sheet.activateListeners(html);
-      }
-    });
+  Hooks.on("renderActorSheetPF2e", (sheet, html) => {
+    if (
+      typeof sheet.activateListeners === "function" &&
+      !sheet._popoutListenersPrimed
+    ) {
+      sheet._popoutListenersPrimed = true;
+      sheet.activateListeners(html);
+    }
+  });
 
-    globalThis.InlineRollLinks?.activatePF2eListeners();
-    console.log("Inline Roll Links listeners activated");
-  }
+  globalThis.InlineRollLinks?.activatePF2eListeners();
+  console.log("Inline Roll Links listeners activated");
 
   PopoutModule.singleton = new PopoutModule();
   PopoutModule.singleton.init();


### PR DESCRIPTION
## Summary
- run PF2E hook setup and inline roll link activation for all systems at ready time

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `make test` *(fails: Cannot find the browser "chrome")*
- `npx testcafe 'chromium:headless --no-sandbox' tests/` *(fails: Unable to open browser: connect ECONNREFUSED 127.0.0.1:44633)*

------
https://chatgpt.com/codex/tasks/task_e_68ab17d75eb88327a2d5674f4686ac70