### PR TITLE
Mirror document events without using private jQuery APIs

### DIFF
--- a/scripts/second-screen.js
+++ b/scripts/second-screen.js
@@ -47,44 +47,14 @@ let isPatched = false;
 async function openSecondScreen(sheet) {
   const popout = await sheet.render(true, { popOut: true });
 
-  const jq = popout.jQuery || window.jQuery;
-  const cloneDelegated = (source, target) => {
-    const events = window.jQuery._data(source, "events");
-    if (!events) return;
-    for (const [type, handlers] of Object.entries(events)) {
-      for (const handler of handlers) {
-        const namespace = handler.namespace ? `.${handler.namespace}` : "";
-        const eventName = `${type}${namespace}`;
-        if (handler.selector) {
-          if (handler.data !== undefined) {
-            jq(target).on(
-              eventName,
-              handler.selector,
-              handler.data,
-              handler.handler,
-            );
-          } else {
-            jq(target).on(eventName, handler.selector, handler.handler);
-          }
-        } else {
-          if (handler.data !== undefined) {
-            jq(target).on(eventName, handler.data, handler.handler);
-          } else {
-            jq(target).on(eventName, handler.handler);
-          }
-        }
-      }
-    }
-  };
-
-  cloneDelegated(window.document, popout.document);
-  if (document.body && popout.document.body) {
-    cloneDelegated(document.body, popout.document.body);
+  if (globalThis.PopoutModule?.singleton) {
+    PopoutModule.singleton.cloneDelegatedEvents(popout);
   }
 
   const newPairs = [
     [window.document, popout.document],
     [window.document.body, popout.document.body],
+    [window.document.documentElement, popout.document.documentElement],
   ];
   pairs.push(...newPairs);
 

--- a/tests/document_event_tests.js
+++ b/tests/document_event_tests.js
@@ -1,0 +1,26 @@
+const { Selector } = require("testcafe");
+
+fixture`Foundry`.page`http://localhost:30000/game`;
+
+test("new document events are mirrored to pop-outs", async (t) => {
+  const firstActor = Selector("#actors .directory-list .directory-item").nth(0);
+  await t.click(firstActor);
+  const popoutButton = Selector(".popout-module-button").filterVisible();
+  await t.click(popoutButton);
+  const mainWindow = await t.getCurrentWindow();
+  await t.switchToWindow((w) => w.url.includes("popout"));
+  const popoutWindow = await t.getCurrentWindow();
+  await t.switchToWindow(mainWindow);
+  await t.eval(() => {
+    window.__popoutEvent = false;
+    jQuery(document).on("popout-test", function () {
+      this.defaultView.__popoutEvent = true;
+    });
+  });
+  await t.switchToWindow(popoutWindow);
+  await t.eval(() => {
+    document.dispatchEvent(new Event("popout-test"));
+  });
+  await t.expect(t.eval(() => window.__popoutEvent)).ok();
+  await t.switchToWindow(mainWindow);
+});


### PR DESCRIPTION
## Summary
- Track jQuery document, body, html and window events and mirror them to pop-out windows without relying on `jQuery._data`
- Propagate delegated events to second-screen popouts via PopoutModule helpers
- Add integration test for mirroring newly-bound document events to pop-outs

## Testing
- `npx eslint popout.js scripts/second-screen.js tests/*.js`
- `npx testcafe chromium:headless tests/document_event_tests.js` *(fails: Cannot find the browser. "chromium:headless" is neither a known browser alias, nor a path to an executable file.)*


------
https://chatgpt.com/codex/tasks/task_e_68abfe85fff08327a88fef8520e8e77c