### PR TITLE
Fix popout element refs and rebind listeners on state node

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1409,7 +1409,6 @@ class PopoutModule {
             child.close();
           }
         }
-        delete app._popoutListenersBound;
         self.poppedOut.delete(appId);
 
         // Force a re-render or close it
@@ -1523,17 +1522,21 @@ class PopoutModule {
           const adoptedNode = targetDoc.adoptNode(state.node);
           body.style.overflow = "auto";
           body.append(adoptedNode);
-          // Update state to reference the adopted node
+          // Update state and application references to the adopted node
           state.node = adoptedNode;
+          app._element = state.node;
+          app.element = $(state.node);
         } catch (error) {
           self.log("Error adopting ApplicationV2 node:", error);
           throw error;
         }
       } else {
         // ApplicationV1 - use the original adoption method
-        const adoptedNode = targetDoc.adoptNode(state.node);
+        targetDoc.adoptNode(state.node);
         body.style.overflow = "auto";
         body.append(state.node);
+        app._element = state.node;
+        app.element = $(state.node);
       }
 
       state.node.style.cssText = `
@@ -1550,13 +1553,9 @@ class PopoutModule {
       app.setPosition({ width: "100%", height: "100%", top: 0, left: 0 });
       app._minimized = null;
 
-      // Re-bind application listeners to the new DOM, but only once per popout
-      if (
-        typeof app.activateListeners === "function" &&
-        !app._popoutListenersBound
-      ) {
-        app.activateListeners(jQuery(popout.document));
-        app._popoutListenersBound = true;
+      // Re-bind application listeners to the new DOM
+      if (typeof app.activateListeners === "function") {
+        app.activateListeners($(state.node));
       }
 
       // Disable touch zoom

--- a/tests/popout_tests.js
+++ b/tests/popout_tests.js
@@ -41,3 +41,38 @@ test("PF2e skill check dialog rolls from a popped-out sheet", async (t) => {
   // Return focus to the main window
   await t.switchToWindow(mainWindow);
 });
+
+test("PF2e skill check after re-render in pop-out still triggers a roll", async (t) => {
+  // Open the first actor in the directory
+  const firstActor = Selector("#actors .directory-list .directory-item").nth(0);
+  await t.click(firstActor);
+
+  // Pop out the actor sheet
+  const popoutButton = Selector(".popout-module-button").filterVisible();
+  await t.click(popoutButton);
+
+  // Capture the main window and switch to the pop-out
+  const mainWindow = await t.getCurrentWindow();
+  await t.switchToWindow((w) => w.url.includes("popout"));
+
+  // Force a re-render of the sheet to ensure listeners re-bind
+  await t.eval(() => game.actors.contents[0].sheet.render(true));
+
+  // Trigger a PF2e skill check (e.g., Perception)
+  const perceptionSkill = Selector('[data-skill="perception"] .skill-name');
+  await t.click(perceptionSkill);
+
+  // Submit the skill-check dialog
+  const messageSelector = Selector("#chat-log .message");
+  const initialCount = await messageSelector.count;
+  const rollButton = Selector(
+    '.dialog button[type="submit"], .dialog button.roll',
+  );
+  await t.click(rollButton);
+
+  // A new chat message should appear as the result of the roll
+  await t.expect(messageSelector.count).gt(initialCount);
+
+  // Return focus to the main window
+  await t.switchToWindow(mainWindow);
+});


### PR DESCRIPTION
## Summary
- update application element references after node adoption
- rebind listeners to the popout's sheet root and drop one-time flag
- add regression tests for skill rolls from popped-out sheets

## Testing
- `npx eslint popout.js tests/popout_tests.js`
- `npx testcafe 'chromium:headless --no-sandbox' tests` *(fails: Cannot find the browser "chromium")*

------
https://chatgpt.com/codex/tasks/task_e_68ac0925728c8327a8198e81423ae0f3