### PR TITLE
Add rollable skill pop-out TestCafe scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Hooks.callAll("PopOut:dialog", app, parent);
 Hooks.callAll("PopOut:close", app, node);
 ```
 
+# Testing
+
+End-to-end tests use [TestCafe](https://testcafe.io). Start a Foundry VTT server on `http://localhost:30000` with the PopOut! module enabled, then run:
+
+```sh
+npx testcafe "chromium --no-sandbox" tests
+```
+
+One scenario opens an actor sheet, pops it out, and clicks a `.rollable` skill button. The test fixture enables the `cloneDocumentEvents` setting so the roll dialog or resulting chat message appears correctly.
+
 # License
 
 This Foundry VTT module, written by @KaKaRoTo.

--- a/tests/popout_tests.js
+++ b/tests/popout_tests.js
@@ -6,7 +6,13 @@ const { Selector } = require("testcafe");
  * still submit rolls correctly. The selectors used below match PF2e's markup
  * and may need adjustment if the system changes.
  */
-fixture`Foundry`.page`http://localhost:30000/game`;
+fixture`Foundry`
+  .page`http://localhost:30000/game`
+  .beforeEach(async (t) => {
+    await t.eval(() =>
+      game.settings.set("popout", "cloneDocumentEvents", true),
+    );
+  });
 
 test("PF2e skill check dialog rolls from a popped-out sheet", async (t) => {
   // Assume user is already logged in and an actor is present in the directory
@@ -37,6 +43,37 @@ test("PF2e skill check dialog rolls from a popped-out sheet", async (t) => {
 
   // A new chat message should appear as the result of the roll
   await t.expect(messageSelector.count).gt(initialCount);
+
+  // Return focus to the main window
+  await t.switchToWindow(mainWindow);
+});
+
+test("rollable skill button rolls from a popped-out sheet", async (t) => {
+  // Open the first actor in the directory
+  const firstActor = Selector("#actors .directory-list .directory-item").nth(0);
+  await t.click(firstActor);
+
+  // Pop out the actor sheet
+  const popoutButton = Selector(".popout-module-button").filterVisible();
+  await t.click(popoutButton);
+
+  // Capture the main window and switch to the pop-out
+  const mainWindow = await t.getCurrentWindow();
+  await t.switchToWindow((w) => w.url.includes("popout"));
+
+  // Click the first rollable element
+  const rollable = Selector(".rollable").filterVisible().nth(0);
+  const messageSelector = Selector("#chat-log .message");
+  const initialCount = await messageSelector.count;
+  await t.click(rollable);
+
+  // A dialog or new chat message should appear
+  const dialog = Selector(".dialog").filterVisible();
+  try {
+    await t.expect(dialog.exists).ok({ timeout: 1000 });
+  } catch {
+    await t.expect(messageSelector.count).gt(initialCount);
+  }
 
   // Return focus to the main window
   await t.switchToWindow(mainWindow);


### PR DESCRIPTION
## Summary
- add beforeEach to enable `cloneDocumentEvents` for all tests
- test clicking a `.rollable` skill in a popped-out actor sheet
- document TestCafe test execution

## Testing
- `npx eslint tests/popout_tests.js`
- `npx testcafe "chromium:headless --no-sandbox" tests/popout_tests.js` *(fails: Cannot find the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0926171483278673842c0b27a1e6