### PR TITLE
Fix PF2e listeners after event cloning

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1604,6 +1604,12 @@ class PopoutModule {
         try {
           // Clone delegated document events afresh for the new window
           self.cloneDelegatedEvents(popout);
+          if (
+            game.system.id === "pf2e" &&
+            typeof app.activateListeners === "function"
+          ) {
+            app.activateListeners(popout.document);
+          }
         } catch (err) {
           self.log("Failed to clone document events", err);
         }


### PR DESCRIPTION
## Summary
- Re-bind PF2e sheet listeners after cloning delegated events

## Testing
- `npx eslint popout.js`
- `npm test` *(fails: Missing script: "test")*
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68ada1fd7aa4832799be16640ca9f715