### PR TITLE
Seed delegated events for multiple targets

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -747,26 +747,34 @@ class PopoutModule {
     const getter =
       typeof getEventListeners === "function" ? getEventListeners : null;
     if (!getter) return;
-    try {
-      const listeners = getter(document);
-      const store = this.jqListeners.document;
-      for (const [type, arr] of Object.entries(listeners)) {
-        for (const l of arr) {
-          const fn = l.listener;
-          if (!fn) continue;
-          const args = [type];
-          if (fn.selector !== undefined) {
-            args.push(fn.selector);
-            if (fn.data !== undefined) args.push(fn.data);
-          } else if (fn.data !== undefined) {
-            args.push(fn.data);
+    for (const { target, name } of [
+      { target: document, name: "document" },
+      { target: document.body, name: "body" },
+      { target: document.documentElement, name: "documentElement" },
+      { target: window, name: "window" },
+    ]) {
+      if (!target) continue;
+      try {
+        const listeners = getter(target);
+        const store = this.jqListeners[name];
+        for (const [type, arr] of Object.entries(listeners)) {
+          for (const l of arr) {
+            const fn = l.listener;
+            if (!fn) continue;
+            const args = [type];
+            if (fn.selector !== undefined) {
+              args.push(fn.selector);
+              if (fn.data !== undefined) args.push(fn.data);
+            } else if (fn.data !== undefined) {
+              args.push(fn.data);
+            }
+            args.push(fn.handler || fn);
+            store.push(args);
           }
-          args.push(fn.handler || fn);
-          store.push(args);
         }
+      } catch {
+        /* no-op */
       }
-    } catch {
-      /* no-op */
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure existing jQuery delegated events from document, body, documentElement, and window are mirrored

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*

------
https://chatgpt.com/codex/tasks/task_e_68adaa3cd8908327aa8e4f8882542204