### PR TITLE
Add PF2e listener support for popped-out windows

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1,5 +1,9 @@
 "use strict";
 
+const PF2E_LISTENERS = [
+  { selector: "[data-action]", event: "click", handlerName: "click" },
+];
+
 class PopoutModule {
   constructor() {
     this.poppedOut = new Map();
@@ -1682,6 +1686,18 @@ class PopoutModule {
             typeof app.activateListeners === "function"
           ) {
             app.activateListeners(popout.document);
+            if (game.system.id === "pf2e") {
+              const pf2eHandlers =
+                globalThis.pf2e?.sheetHandler ?? globalThis.sheetHandler ?? {};
+              for (const { selector, event, handlerName } of PF2E_LISTENERS) {
+                const handler = pf2eHandlers[handlerName];
+                if (typeof handler !== "function") continue;
+                const elements = popout.document.querySelectorAll(selector);
+                for (const el of elements) {
+                  el.addEventListener(event, handler);
+                }
+              }
+            }
           }
         } catch (err) {
           self.log("Failed to clone document events", err);


### PR DESCRIPTION
## Summary
- define `PF2E_LISTENERS` mapping popout selectors to PF2e handler names
- register PF2e-specific handlers after activating listeners in a popout

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68adb07286a8832798d75d8ee42b7782