### PR TITLE
Use getter for app.element during DOM adoption

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1602,7 +1602,10 @@ class PopoutModule {
           // Update state and application references to the adopted node
           state.node = adoptedNode;
           app._element = state.node;
-          app.element = $(state.node);
+          Object.defineProperty(app, "element", {
+            configurable: true,
+            get: () => $(state.node),
+          });
         } catch (error) {
           self.log("Error adopting ApplicationV2 node:", error);
           throw error;
@@ -1613,7 +1616,10 @@ class PopoutModule {
         body.style.overflow = "auto";
         body.append(state.node);
         app._element = state.node;
-        app.element = $(state.node);
+        Object.defineProperty(app, "element", {
+          configurable: true,
+          get: () => $(state.node),
+        });
       }
 
       state.node.style.cssText = `


### PR DESCRIPTION
## Summary
- Avoid direct assignment to `app.element` when adopting DOM nodes
- Define a getter returning the jQuery wrapper for `state.node`

## Testing
- `npx eslint popout.js`
- `npx testcafe 'chrome:headless' tests/` *(fails: Cannot find the browser. "chrome:headless" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68adb3cc8ab883279ed3016bca0f9385