### PR TITLE
Clear mutation observer records before reattachment

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1237,6 +1237,7 @@ class PopoutModule {
             options,
           });
           observer.disconnect();
+          observer.takeRecords();
         }
       }
     }
@@ -1715,6 +1716,7 @@ class PopoutModule {
           const target = entry.key?.toLowerCase()?.includes("body")
             ? popout.document.body
             : popout.document;
+          entry.observer.takeRecords();
           entry.observer.observe(target, entry.options);
           if (!app[entry.container]) app[entry.container] = {};
           app[entry.container][entry.key] = entry.observer;


### PR DESCRIPTION
## Summary
- clear pending mutation records after disconnecting observers
- reset observer records before reattaching in pop-out window

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68adbe936ccc8327b09779da262f964f