### PR TITLE
Retain MutationObserver targets during popout reattachment

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1230,11 +1230,15 @@ class PopoutModule {
               childList: true,
               subtree: true,
             };
+          const target = key?.toLowerCase()?.includes("body")
+            ? appElement
+            : document;
           state.observers.push({
             container: containerName,
             key,
             observer,
             options,
+            target,
           });
           observer.disconnect();
           observer.takeRecords();
@@ -1713,9 +1717,9 @@ class PopoutModule {
       // routines continue to function within the popout document.
       for (const entry of state.observers) {
         try {
-          const target = entry.key?.toLowerCase()?.includes("body")
-            ? popout.document.body
-            : popout.document;
+          let target = entry.target;
+          if (target === document) target = popout.document;
+          if (target === document.body) target = state.node;
           entry.observer.takeRecords();
           entry.observer.observe(target, entry.options);
           if (!app[entry.container]) app[entry.container] = {};


### PR DESCRIPTION
## Summary
- preserve MutationObserver targets when disconnecting a sheet
- reattach observers to the original target or sheet root in the popout window

## Testing
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser "chrome")*

------
https://chatgpt.com/codex/tasks/task_e_68adc13c23ac832795cb3932f56e2dd7