### PR TITLE
Update observers after app render in popouts

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1868,7 +1868,19 @@ class PopoutModule {
         if (self.poppedOut.has(app)) {
           const st = self.poppedOut.get(app);
           const newNode = self.getAppElement(app);
-          if (newNode) st.node = newNode;
+          if (newNode) {
+            st.node = newNode;
+            for (const entry of st.observers) {
+              try {
+                entry.observer.disconnect();
+                entry.observer.observe(st.node, entry.options);
+                if (!app[entry.container]) app[entry.container] = {};
+                app[entry.container][entry.key] = entry.observer;
+              } catch (error) {
+                self.log("Error updating MutationObserver:", error);
+              }
+            }
+          }
           self.poppedOut.set(app, st);
         }
       };


### PR DESCRIPTION
## Summary
- ensure MutationObservers are reattached to new nodes after a popped-out app re-renders

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser. "chrome" is neither a known browser alias, nor a path to an executable file.)*

------
https://chatgpt.com/codex/tasks/task_e_68adc228be208327823ef274c315f90c