### PR TITLE
Ensure MutationObservers reattach to correct DOM in popout renders

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1872,10 +1872,16 @@ class PopoutModule {
             st.node = newNode;
             for (const entry of st.observers) {
               try {
-                entry.observer.disconnect();
-                entry.observer.observe(st.node, entry.options);
+                const observer = entry.observer;
+                let target = entry.target;
+                if (target === document) target = popout.document;
+                else if (target === document.body) target = st.node;
+                observer.disconnect();
+                observer.takeRecords(); // discard old mutation entries
+                observer.observe(target, entry.options);
+                entry.target = target; // remember for later renders
                 if (!app[entry.container]) app[entry.container] = {};
-                app[entry.container][entry.key] = entry.observer;
+                app[entry.container][entry.key] = observer;
               } catch (error) {
                 self.log("Error updating MutationObserver:", error);
               }


### PR DESCRIPTION
## Summary
- Reattach MutationObservers during app rerender to the proper DOM target rather than always the popout node
- Discard stale mutation records and update stored targets for future renders

## Testing
- `make format`
- `make lint`
- `make test` *(fails: Cannot find the browser "chrome")*

------
https://chatgpt.com/codex/tasks/task_e_68adc63231d0832798a4a4314238a934