### PR TITLE
Fix MutationObserver target translation for popouts

### DIFF
--- a/popout.js
+++ b/popout.js
@@ -1229,7 +1229,7 @@ class PopoutModule {
               subtree: true,
             };
           const target = key?.toLowerCase()?.includes("body")
-            ? appElement
+            ? document.body
             : document;
           state.observers.push({
             container: containerName,
@@ -1717,7 +1717,7 @@ class PopoutModule {
         try {
           let target = entry.target;
           if (target === document) target = popout.document;
-          if (target === document.body) target = state.node;
+          else if (target === document.body) target = popout.document.body;
           entry.observer.takeRecords();
           entry.observer.observe(target, entry.options);
           if (!app[entry.container]) app[entry.container] = {};


### PR DESCRIPTION
## Summary
- store original document targets for disconnected MutationObservers
- translate stored targets to the popout window on reattachment and flush stale mutations

## Testing
- `npx prettier -w popout.js`
- `npx eslint popout.js`
- `npx testcafe chrome tests/` *(fails: Cannot find the browser)*

------
https://chatgpt.com/codex/tasks/task_e_68add4e3feb083278250b34c9116171c